### PR TITLE
feat: try-on history, contract cancel, uniform proposals

### DIFF
--- a/VTOS.API/Controllers/ChatController.cs
+++ b/VTOS.API/Controllers/ChatController.cs
@@ -18,16 +18,25 @@ public class ChatController : ControllerBase
 {
     private readonly IGetChatMessagesQueryHandler _getMessagesHandler;
     private readonly ISendChatMessageCommandHandler _sendMessageHandler;
+    private readonly ISendUniformProposalCommandHandler _sendProposalHandler;
+    private readonly IAcceptUniformProposalCommandHandler _acceptProposalHandler;
     private readonly ICurrentUserService _currentUser;
+    private readonly IImageUploadService _imageUploadService;
 
     public ChatController(
         IGetChatMessagesQueryHandler getMessagesHandler,
         ISendChatMessageCommandHandler sendMessageHandler,
-        ICurrentUserService currentUser)
+        ISendUniformProposalCommandHandler sendProposalHandler,
+        IAcceptUniformProposalCommandHandler acceptProposalHandler,
+        ICurrentUserService currentUser,
+        IImageUploadService imageUploadService)
     {
         _getMessagesHandler = getMessagesHandler;
         _sendMessageHandler = sendMessageHandler;
+        _sendProposalHandler = sendProposalHandler;
+        _acceptProposalHandler = acceptProposalHandler;
         _currentUser = currentUser;
+        _imageUploadService = imageUploadService;
     }
 
     /// <summary>Get chat messages for a channel (complaint or contract).</summary>
@@ -70,6 +79,71 @@ public class ChatController : ControllerBase
         if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
         return StatusCode(StatusCodes.Status201Created, result.Value);
     }
+
+    /// <summary>Provider sends a uniform proposal with image in contract chat.</summary>
+    [HttpPost("messages/proposal")]
+    [Authorize(Roles = "Provider")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(typeof(SendUniformProposalResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> SendUniformProposal(
+        [FromForm] SendUniformProposalRequest request,
+        CancellationToken ct = default)
+    {
+        // Upload image to MinIO first
+        if (request.Image == null || request.Image.Length == 0)
+            return BadRequest(new { error = "Image file is required.", code = "IMAGE_REQUIRED" });
+
+        if (request.Image.Length > 5 * 1024 * 1024)
+            return BadRequest(new { error = "File too large. Max 5 MB.", code = "FILE_TOO_LARGE" });
+
+        var allowed = new[] { "image/jpeg", "image/png", "image/webp" };
+        if (!allowed.Contains(request.Image.ContentType))
+            return BadRequest(new { error = "Invalid image type. Use JPEG, PNG, or WebP.", code = "INVALID_TYPE" });
+
+        string imageUrl;
+        using (var stream = request.Image.OpenReadStream())
+        {
+            imageUrl = await _imageUploadService.UploadAsync(stream, request.Image.FileName, "proposals", ct);
+        }
+
+        var command = new SendUniformProposalCommand(
+            _currentUser.UserId,
+            ChatChannelType.Contract,
+            request.ChannelId,
+            imageUrl,
+            request.OutfitName
+        );
+
+        var result = await _sendProposalHandler.HandleAsync(command, ct);
+        if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
+        return StatusCode(StatusCodes.Status201Created, result.Value);
+    }
+
+    /// <summary>School accepts a uniform proposal — creates outfit in school catalog.</summary>
+    [HttpPost("proposals/{messageId:guid}/accept")]
+    [Authorize(Roles = "School")]
+    [ProducesResponseType(typeof(AcceptUniformProposalResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> AcceptUniformProposal(Guid messageId, CancellationToken ct = default)
+    {
+        var result = await _acceptProposalHandler.HandleAsync(
+            new AcceptUniformProposalCommand(_currentUser.UserId, messageId), ct);
+        if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
+        return Ok(result.Value);
+    }
 }
 
 public record SendMessageRequest(string Content);
+
+public class SendUniformProposalRequest
+{
+    /// <summary>Contract channel ID</summary>
+    public Guid ChannelId { get; set; }
+
+    /// <summary>Proposed uniform name</summary>
+    public string OutfitName { get; set; } = string.Empty;
+
+    /// <summary>Uniform image file (jpg/png/webp, max 5MB)</summary>
+    public IFormFile Image { get; set; } = null!;
+}

--- a/VTOS.API/Controllers/SchoolsController.cs
+++ b/VTOS.API/Controllers/SchoolsController.cs
@@ -85,6 +85,7 @@ public class SchoolsController : ControllerBase
     private readonly ICreateContractCommandHandler _createContractHandler;
     private readonly IGetContractsQueryHandler _getContractsHandler;
     private readonly IGetContractDetailQueryHandler _getContractDetailHandler;
+    private readonly ICancelContractCommandHandler _cancelContractHandler;
     // Phase 4 — Delivery & Distribution
     private readonly IConfirmDeliveryCommandHandler _confirmDeliveryHandler;
     private readonly IGetVerifyQuantityQueryHandler _getVerifyQuantityHandler;
@@ -158,6 +159,7 @@ public class SchoolsController : ControllerBase
         ICreateContractCommandHandler createContractHandler,
         IGetContractsQueryHandler getContractsHandler,
         IGetContractDetailQueryHandler getContractDetailHandler,
+        ICancelContractCommandHandler cancelContractHandler,
         // Phase 4
         IConfirmDeliveryCommandHandler confirmDeliveryHandler,
         IGetVerifyQuantityQueryHandler getVerifyQuantityHandler,
@@ -228,6 +230,7 @@ public class SchoolsController : ControllerBase
         _createContractHandler = createContractHandler;
         _getContractsHandler = getContractsHandler;
         _getContractDetailHandler = getContractDetailHandler;
+        _cancelContractHandler = cancelContractHandler;
         _confirmDeliveryHandler = confirmDeliveryHandler;
         _getVerifyQuantityHandler = getVerifyQuantityHandler;
         _reportDefectHandler = reportDefectHandler;
@@ -1294,6 +1297,18 @@ public class SchoolsController : ControllerBase
     {
         var result = await _getContractDetailHandler.HandleAsync(
             new GetContractDetailQuery(_currentUser.UserId, "School", id), ct);
+        if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
+        return Ok(result.Value);
+    }
+
+    /// <summary>Cancel a Pending contract (before Provider accepts).</summary>
+    [HttpPut("me/contracts/{id}/cancel")]
+    [ProducesResponseType(typeof(ContractDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CancelContract(Guid id, CancellationToken ct)
+    {
+        var result = await _cancelContractHandler.HandleAsync(
+            new CancelContractCommand(_currentUser.UserId, id), ct);
         if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
         return Ok(result.Value);
     }

--- a/VTOS.API/Controllers/TryOnController.cs
+++ b/VTOS.API/Controllers/TryOnController.cs
@@ -3,13 +3,14 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using VTOS.Application.Abstractions;
 using VTOS.Application.Features.TryOn.Commands.GuestTryOn;
+using VTOS.Application.Features.TryOn.Queries;
 
 namespace VTOS.API.Controllers;
 
 /// <summary>
-/// Request DTO for guest try-on
+/// Request DTO for try-on
 /// </summary>
-public class GuestTryOnRequest
+public class TryOnRequest
 {
     /// <summary>
     /// ID of the outfit to try on
@@ -22,7 +23,7 @@ public class GuestTryOnRequest
     public IFormFile Photo { get; set; } = null!;
 
     /// <summary>
-    /// Optional session ID for rate limiting
+    /// Optional session ID for rate limiting (guest users only)
     /// </summary>
     public string? GuestSessionId { get; set; }
 }
@@ -36,35 +37,44 @@ public class TryOnController : ControllerBase
 {
     private readonly IGuestTryOnCommandHandler _guestTryOnHandler;
     private readonly IValidator<GuestTryOnCommand> _guestTryOnValidator;
+    private readonly IGetParentTryOnHistoryQueryHandler _historyHandler;
+    private readonly ICurrentUserService _currentUser;
     private readonly ILogger<TryOnController> _logger;
 
     public TryOnController(
         IGuestTryOnCommandHandler guestTryOnHandler,
         IValidator<GuestTryOnCommand> guestTryOnValidator,
+        IGetParentTryOnHistoryQueryHandler historyHandler,
+        ICurrentUserService currentUser,
         ILogger<TryOnController> logger)
     {
         _guestTryOnHandler = guestTryOnHandler;
         _guestTryOnValidator = guestTryOnValidator;
+        _historyHandler = historyHandler;
+        _currentUser = currentUser;
         _logger = logger;
     }
 
     /// <summary>
-    /// Perform virtual try-on for guest users
+    /// Perform virtual try-on (for both guest and logged-in users)
     /// </summary>
-    [HttpPost("guest")]
+    [HttpPost("request")]
     [AllowAnonymous]
     [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(GuestTryOnResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
-    public async Task<IActionResult> GuestTryOn(
-        [FromForm] GuestTryOnRequest request,
+    public async Task<IActionResult> TryOnRequest(
+        [FromForm] TryOnRequest request,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Guest try-on request. OutfitId: {OutfitId}, Session: {SessionId}", 
-            request.OutfitId, request.GuestSessionId ?? "new");
+        // Extract UserId if authenticated
+        Guid? userId = User.Identity?.IsAuthenticated == true ? _currentUser.UserId : null;
 
-        var command = new GuestTryOnCommand(request.GuestSessionId, request.OutfitId, request.Photo);
+        _logger.LogInformation("Try-on request. OutfitId: {OutfitId}, UserId: {UserId}, Session: {SessionId}", 
+            request.OutfitId, userId?.ToString() ?? "guest", request.GuestSessionId ?? "new");
+
+        var command = new GuestTryOnCommand(request.GuestSessionId, request.OutfitId, request.Photo, userId);
 
         // Validate
         var validationResult = await _guestTryOnValidator.ValidateAsync(command, cancellationToken);
@@ -78,7 +88,6 @@ public class TryOnController : ControllerBase
 
         if (!result.IsSuccess)
         {
-            // Return appropriate status code based on error
             return result.ErrorCode switch
             {
                 "RATE_LIMIT_EXCEEDED" => StatusCode(StatusCodes.Status429TooManyRequests, 
@@ -88,6 +97,25 @@ public class TryOnController : ControllerBase
             };
         }
 
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Get try-on history for the current logged-in parent
+    /// </summary>
+    [HttpGet("history")]
+    [Authorize(Roles = "Parent")]
+    [ProducesResponseType(typeof(GetParentTryOnHistoryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetTryOnHistory(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetParentTryOnHistoryQuery(_currentUser.UserId, page, pageSize);
+        var result = await _historyHandler.HandleAsync(query, cancellationToken);
+        if (!result.IsSuccess)
+            return BadRequest(new { error = result.Error, code = result.ErrorCode });
         return Ok(result.Value);
     }
 }

--- a/VTOS.Application/Features/Chat/Commands/AcceptUniformProposalCommand.cs
+++ b/VTOS.Application/Features/Chat/Commands/AcceptUniformProposalCommand.cs
@@ -1,0 +1,131 @@
+using Microsoft.EntityFrameworkCore;
+using VTOS.Application.Abstractions;
+using VTOS.Application.Common;
+using VTOS.Application.Features.Chat.Queries;
+using VTOS.Application.Features.Notifications;
+using VTOS.Domain.Entities;
+using VTOS.Domain.Enums;
+
+namespace VTOS.Application.Features.Chat.Commands;
+
+// ─── Accept Uniform Proposal (School only) ───
+
+public record AcceptUniformProposalCommand(Guid UserId, Guid MessageId);
+
+public record AcceptUniformProposalResponse(
+    Guid OutfitId,
+    string OutfitName,
+    string? MainImageURL,
+    Guid SchoolId
+);
+
+public interface IAcceptUniformProposalCommandHandler
+{
+    Task<Result<AcceptUniformProposalResponse>> HandleAsync(AcceptUniformProposalCommand command, CancellationToken ct = default);
+}
+
+public class AcceptUniformProposalCommandHandler : IAcceptUniformProposalCommandHandler
+{
+    private readonly IApplicationDbContext _db;
+    private readonly IChatBroadcaster _broadcaster;
+    private readonly INotificationService _notificationService;
+
+    public AcceptUniformProposalCommandHandler(
+        IApplicationDbContext db,
+        IChatBroadcaster broadcaster,
+        INotificationService notificationService)
+    {
+        _db = db;
+        _broadcaster = broadcaster;
+        _notificationService = notificationService;
+    }
+
+    public async Task<Result<AcceptUniformProposalResponse>> HandleAsync(
+        AcceptUniformProposalCommand command, CancellationToken ct = default)
+    {
+        // 1. Verify user is School
+        var schoolMgr = await _db.SchoolManagers.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.UserID == command.UserId, ct);
+        if (schoolMgr == null)
+            return Result<AcceptUniformProposalResponse>.Failure("Only schools can accept proposals.", "NOT_SCHOOL");
+
+        var schoolId = schoolMgr.SchoolID;
+
+        // 2. Find the proposal message
+        var message = await _db.ChatMessages
+            .FirstOrDefaultAsync(m => m.Id == command.MessageId
+                && m.MessageType == ChatMessageType.UniformProposal
+                && m.ProposalStatus == "Pending", ct);
+
+        if (message == null)
+            return Result<AcceptUniformProposalResponse>.Failure(
+                "Proposal not found or already processed.", "PROPOSAL_NOT_FOUND");
+
+        // 3. Verify School has access to this contract channel
+        if (message.ChannelType != ChatChannelType.Contract)
+            return Result<AcceptUniformProposalResponse>.Failure("Invalid channel type.", "INVALID_CHANNEL");
+
+        var contract = await _db.Contracts.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == message.ChannelId && c.SchoolID == schoolId, ct);
+        if (contract == null)
+            return Result<AcceptUniformProposalResponse>.Failure("Access denied.", "ACCESS_DENIED");
+
+        // 4. Create new Outfit in School catalog
+        var outfitName = message.ProposalOutfitName ?? "Đề xuất từ NCC";
+        var outfit = new Outfit
+        {
+            Id = Guid.NewGuid(),
+            SchoolID = schoolId,
+            OutfitName = outfitName,
+            MainImageURL = message.ImageUrl,
+            IsAvailable = true,
+            IsDeleted = false,
+            Price = 0 // School will set the price later
+        };
+
+        _db.Outfits.Add(outfit);
+
+        // 5. Mark proposal as Accepted
+        message.ProposalStatus = "Accepted";
+
+        // 6. Auto-send system message WITH image back to chat
+        var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == command.UserId, ct);
+        var systemMsg = new ChatMessage
+        {
+            Id = Guid.NewGuid(),
+            ChannelType = message.ChannelType,
+            ChannelId = message.ChannelId,
+            SenderUserId = command.UserId,
+            SenderName = "Hệ thống",
+            Content = $"✅ Trường đã chấp nhận đề xuất đồng phục '{outfitName}'",
+            SentAt = DateTime.UtcNow,
+            MessageType = ChatMessageType.SystemNotification,
+            ImageUrl = message.ImageUrl // Same image → Provider sees which one was picked
+        };
+
+        _db.ChatMessages.Add(systemMsg);
+        await _db.SaveChangesAsync(ct);
+
+        // 7. Broadcast system message via SignalR (real-time)
+        await _broadcaster.BroadcastMessageAsync(
+            message.ChannelType.ToString(), message.ChannelId,
+            new ChatMessageDto(systemMsg.Id, systemMsg.SenderUserId, systemMsg.SenderName,
+                systemMsg.Content, systemMsg.SentAt, false,
+                systemMsg.MessageType.ToString(), systemMsg.ImageUrl, null, null),
+            ct);
+
+        // 8. Notify Provider via bell icon
+        try
+        {
+            await _notificationService.NotifyProviderAsync(contract.ProviderID,
+                "✅ Đề xuất đồng phục được chấp nhận",
+                $"Trường đã chấp nhận đề xuất đồng phục '{outfitName}'.",
+                "Contract", contract.Id, "Contract",
+                "/provider/contracts", ct);
+        }
+        catch { /* Don't fail the main operation */ }
+
+        return Result<AcceptUniformProposalResponse>.Success(
+            new AcceptUniformProposalResponse(outfit.Id, outfitName, message.ImageUrl, schoolId));
+    }
+}

--- a/VTOS.Application/Features/Chat/Commands/SendChatMessageCommand.cs
+++ b/VTOS.Application/Features/Chat/Commands/SendChatMessageCommand.cs
@@ -62,7 +62,8 @@ public class SendChatMessageCommandHandler : ISendChatMessageCommandHandler
         // Broadcast via SignalR
         await _broadcaster.BroadcastMessageAsync(
             command.ChannelType.ToString(), command.ChannelId,
-            new ChatMessageDto(message.Id, message.SenderUserId, message.SenderName, message.Content, message.SentAt, false),
+            new ChatMessageDto(message.Id, message.SenderUserId, message.SenderName, message.Content, message.SentAt, false,
+                message.MessageType.ToString(), message.ImageUrl, message.ProposalStatus, message.ProposalOutfitName),
             ct);
 
         return Result<SendChatMessageResponse>.Success(

--- a/VTOS.Application/Features/Chat/Commands/SendUniformProposalCommand.cs
+++ b/VTOS.Application/Features/Chat/Commands/SendUniformProposalCommand.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using VTOS.Application.Abstractions;
+using VTOS.Application.Common;
+using VTOS.Application.Features.Chat.Queries;
+using VTOS.Domain.Entities;
+using VTOS.Domain.Enums;
+
+namespace VTOS.Application.Features.Chat.Commands;
+
+// ─── Send Uniform Proposal (Provider only) ───
+
+public record SendUniformProposalCommand(
+    Guid UserId,
+    ChatChannelType ChannelType,
+    Guid ChannelId,
+    string ImageUrl,
+    string OutfitName
+);
+
+public record SendUniformProposalResponse(Guid MessageId, DateTime SentAt);
+
+public interface ISendUniformProposalCommandHandler
+{
+    Task<Result<SendUniformProposalResponse>> HandleAsync(SendUniformProposalCommand command, CancellationToken ct = default);
+}
+
+public class SendUniformProposalCommandHandler : ISendUniformProposalCommandHandler
+{
+    private readonly IApplicationDbContext _db;
+    private readonly IChatBroadcaster _broadcaster;
+
+    public SendUniformProposalCommandHandler(IApplicationDbContext db, IChatBroadcaster broadcaster)
+    {
+        _db = db;
+        _broadcaster = broadcaster;
+    }
+
+    public async Task<Result<SendUniformProposalResponse>> HandleAsync(SendUniformProposalCommand command, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(command.ImageUrl))
+            return Result<SendUniformProposalResponse>.Failure("Image URL is required for a uniform proposal.", "IMAGE_REQUIRED");
+
+        if (string.IsNullOrWhiteSpace(command.OutfitName))
+            return Result<SendUniformProposalResponse>.Failure("Outfit name is required.", "NAME_REQUIRED");
+
+        var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == command.UserId, ct);
+        if (user == null)
+            return Result<SendUniformProposalResponse>.Failure("User not found.", "USER_NOT_FOUND");
+
+        // Verify sender is a Provider
+        var providerMgr = await _db.ProviderManagers.AsNoTracking().FirstOrDefaultAsync(m => m.UserID == user.Id, ct);
+        if (providerMgr == null)
+            return Result<SendUniformProposalResponse>.Failure("Only providers can send uniform proposals.", "NOT_PROVIDER");
+
+        // Verify access to the contract channel
+        if (command.ChannelType != ChatChannelType.Contract)
+            return Result<SendUniformProposalResponse>.Failure("Uniform proposals can only be sent in contract channels.", "INVALID_CHANNEL");
+
+        var hasAccess = await _db.Contracts.AsNoTracking().AnyAsync(c =>
+            c.Id == command.ChannelId && c.ProviderID == providerMgr.ProviderID, ct);
+        if (!hasAccess)
+            return Result<SendUniformProposalResponse>.Failure("Access denied.", "ACCESS_DENIED");
+
+        var message = new ChatMessage
+        {
+            Id = Guid.NewGuid(),
+            ChannelType = command.ChannelType,
+            ChannelId = command.ChannelId,
+            SenderUserId = command.UserId,
+            SenderName = user.FullName ?? user.Email ?? "Unknown",
+            Content = $"📋 Đề xuất đồng phục: {command.OutfitName}",
+            SentAt = DateTime.UtcNow,
+            MessageType = ChatMessageType.UniformProposal,
+            ImageUrl = command.ImageUrl,
+            ProposalStatus = "Pending",
+            ProposalOutfitName = command.OutfitName
+        };
+
+        _db.ChatMessages.Add(message);
+        await _db.SaveChangesAsync(ct);
+
+        // Broadcast via SignalR
+        await _broadcaster.BroadcastMessageAsync(
+            command.ChannelType.ToString(), command.ChannelId,
+            new ChatMessageDto(message.Id, message.SenderUserId, message.SenderName,
+                message.Content, message.SentAt, false,
+                message.MessageType.ToString(), message.ImageUrl,
+                message.ProposalStatus, message.ProposalOutfitName),
+            ct);
+
+        return Result<SendUniformProposalResponse>.Success(
+            new SendUniformProposalResponse(message.Id, message.SentAt));
+    }
+}

--- a/VTOS.Application/Features/Chat/Queries/GetChatMessagesQuery.cs
+++ b/VTOS.Application/Features/Chat/Queries/GetChatMessagesQuery.cs
@@ -13,7 +13,11 @@ public record ChatMessageDto(
     string SenderName,
     string Content,
     DateTime SentAt,
-    bool IsMe
+    bool IsMe,
+    string MessageType = "Text",
+    string? ImageUrl = null,
+    string? ProposalStatus = null,
+    string? ProposalOutfitName = null
 );
 
 public record GetChatMessagesResponse(
@@ -51,7 +55,11 @@ public class GetChatMessagesQueryHandler : IGetChatMessagesQueryHandler
             .Take(query.PageSize)
             .Select(m => new ChatMessageDto(
                 m.Id, m.SenderUserId, m.SenderName,
-                m.Content, m.SentAt, m.SenderUserId == query.UserId
+                m.Content, m.SentAt, m.SenderUserId == query.UserId,
+                m.MessageType.ToString(),
+                m.ImageUrl,
+                m.ProposalStatus,
+                m.ProposalOutfitName
             ))
             .ToListAsync(ct);
 

--- a/VTOS.Application/Features/Contracts/Commands/ContractCommandHandlers.cs
+++ b/VTOS.Application/Features/Contracts/Commands/ContractCommandHandlers.cs
@@ -309,3 +309,57 @@ public class RejectContractCommandHandler : IRejectContractCommandHandler
         return Result<ContractDto>.Success(ContractMapper.MapToDto(contract));
     }
 }
+
+// ─── Cancel Contract Handler (School) ───
+public class CancelContractCommandHandler : ICancelContractCommandHandler
+{
+    private readonly IApplicationDbContext _context;
+    private readonly INotificationService _notificationService;
+
+    public CancelContractCommandHandler(IApplicationDbContext context, INotificationService notificationService)
+    {
+        _context = context;
+        _notificationService = notificationService;
+    }
+
+    public async Task<Result<ContractDto>> HandleAsync(
+        CancelContractCommand command, CancellationToken ct = default)
+    {
+        // Resolve SchoolID from UserId
+        var schoolMgr = await _context.SchoolManagers.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.UserID == command.UserId, ct);
+        if (schoolMgr?.SchoolID == null)
+            return Result<ContractDto>.Failure("User is not linked to a school.", "NOT_SCHOOL");
+
+        var schoolId = schoolMgr.SchoolID;
+
+        var contract = await ContractMapper.IncludeAll(_context.Contracts.AsQueryable())
+            .FirstOrDefaultAsync(c => c.Id == command.ContractId && c.SchoolID == schoolId, ct);
+
+        if (contract == null)
+            return Result<ContractDto>.Failure("Contract not found.", "NOT_FOUND");
+
+        if (contract.Status != "Pending")
+            return Result<ContractDto>.Failure(
+                $"Contract is '{contract.Status}', only Pending contracts can be cancelled.",
+                "INVALID_STATUS");
+
+        contract.Status = "Cancelled";
+        contract.RejectedAt = DateTime.UtcNow;
+        contract.RejectionReason = "Cancelled by school";
+        await _context.SaveChangesAsync(ct);
+
+        // Notify provider
+        try
+        {
+            await _notificationService.NotifyProviderAsync(contract.ProviderID,
+                "🚫 Hợp đồng đã bị hủy",
+                $"Trường {contract.School?.SchoolName} đã hủy hợp đồng: {contract.ContractName}.",
+                "Contract", contract.Id, "Contract",
+                "/provider/contracts", ct);
+        }
+        catch { /* Don't fail the main operation */ }
+
+        return Result<ContractDto>.Success(ContractMapper.MapToDto(contract));
+    }
+}

--- a/VTOS.Application/Features/Contracts/Commands/ContractCommands.cs
+++ b/VTOS.Application/Features/Contracts/Commands/ContractCommands.cs
@@ -26,3 +26,11 @@ public interface IRejectContractCommandHandler
 {
     Task<Result<ContractDto>> HandleAsync(RejectContractCommand command, CancellationToken ct = default);
 }
+
+// ── Cancel Contract (School) ──
+public record CancelContractCommand(Guid UserId, Guid ContractId);
+
+public interface ICancelContractCommandHandler
+{
+    Task<Result<ContractDto>> HandleAsync(CancelContractCommand command, CancellationToken ct = default);
+}

--- a/VTOS.Application/Features/TryOn/Commands/GuestTryOn/GuestTryOnCommand.cs
+++ b/VTOS.Application/Features/TryOn/Commands/GuestTryOn/GuestTryOnCommand.cs
@@ -3,11 +3,11 @@ using Microsoft.AspNetCore.Http;
 namespace VTOS.Application.Features.TryOn.Commands.GuestTryOn;
 
 /// <summary>
-/// Command for guest virtual try-on request
+/// Command for virtual try-on request (both guest and logged-in users)
 /// </summary>
 public record GuestTryOnCommand(
     /// <summary>
-    /// Optional guest session ID for rate limiting
+    /// Optional guest session ID for rate limiting (guest users)
     /// </summary>
     string? GuestSessionId,
     
@@ -19,5 +19,10 @@ public record GuestTryOnCommand(
     /// <summary>
     /// User's photo to apply the outfit to
     /// </summary>
-    IFormFile Photo
+    IFormFile Photo,
+
+    /// <summary>
+    /// Optional user ID for logged-in users (links history to their account)
+    /// </summary>
+    Guid? UserId = null
 );

--- a/VTOS.Application/Features/TryOn/Commands/GuestTryOn/GuestTryOnCommandHandler.cs
+++ b/VTOS.Application/Features/TryOn/Commands/GuestTryOn/GuestTryOnCommandHandler.cs
@@ -53,11 +53,23 @@ public class GuestTryOnCommandHandler : IGuestTryOnCommandHandler
         _logger.LogInformation("Processing guest try-on for session: {SessionId}, outfit: {OutfitId}", 
             guestSessionId, command.OutfitId);
 
-        // Step 2: Check rate limit (5 tries per session per day)
+        // Step 2: Check rate limit
         var today = DateTime.UtcNow.Date;
-        var tryCount = await _context.TryOnHistories
-            .CountAsync(t => t.GuestSessionID == guestSessionId 
-                && t.TryOnTimestamp.Date == today, cancellationToken);
+        int tryCount;
+        if (command.UserId.HasValue)
+        {
+            // Logged-in user: rate limit by UserID
+            tryCount = await _context.TryOnHistories
+                .CountAsync(t => t.UserID == command.UserId.Value
+                    && t.TryOnTimestamp.Date == today, cancellationToken);
+        }
+        else
+        {
+            // Guest: rate limit by session ID
+            tryCount = await _context.TryOnHistories
+                .CountAsync(t => t.GuestSessionID == guestSessionId 
+                    && t.TryOnTimestamp.Date == today, cancellationToken);
+        }
 
         if (tryCount >= _maxTriesPerSession)
         {
@@ -158,6 +170,7 @@ public class GuestTryOnCommandHandler : IGuestTryOnCommandHandler
         var history = new TryOnHistory
         {
             GuestSessionID = guestSessionId,
+            UserID = command.UserId,
             OutfitID = command.OutfitId,
             UploadedPhotoURL = humanImageUrl,
             ResultPhotoURL = resultImageUrl,

--- a/VTOS.Application/Features/TryOn/Queries/GetParentTryOnHistoryQuery.cs
+++ b/VTOS.Application/Features/TryOn/Queries/GetParentTryOnHistoryQuery.cs
@@ -1,0 +1,63 @@
+using Microsoft.EntityFrameworkCore;
+using VTOS.Application.Abstractions;
+using VTOS.Application.Common;
+
+namespace VTOS.Application.Features.TryOn.Queries;
+
+public record GetParentTryOnHistoryQuery(Guid UserId, int Page = 1, int PageSize = 20);
+
+public record TryOnHistoryDto(
+    Guid Id,
+    Guid OutfitId,
+    string OutfitName,
+    string? OutfitImage,
+    string? ResultPhotoUrl,
+    string? UploadedPhotoUrl,
+    DateTime TryOnTimestamp
+);
+
+public record GetParentTryOnHistoryResponse(
+    IReadOnlyList<TryOnHistoryDto> Items,
+    int Total,
+    int Page,
+    int PageSize
+);
+
+public interface IGetParentTryOnHistoryQueryHandler
+{
+    Task<Result<GetParentTryOnHistoryResponse>> HandleAsync(GetParentTryOnHistoryQuery query, CancellationToken ct = default);
+}
+
+public class GetParentTryOnHistoryQueryHandler : IGetParentTryOnHistoryQueryHandler
+{
+    private readonly IApplicationDbContext _db;
+
+    public GetParentTryOnHistoryQueryHandler(IApplicationDbContext db) => _db = db;
+
+    public async Task<Result<GetParentTryOnHistoryResponse>> HandleAsync(
+        GetParentTryOnHistoryQuery query, CancellationToken ct = default)
+    {
+        var q = _db.TryOnHistories.AsNoTracking()
+            .Where(t => t.UserID == query.UserId)
+            .OrderByDescending(t => t.TryOnTimestamp);
+
+        var total = await q.CountAsync(ct);
+        var items = await q
+            .Skip((query.Page - 1) * query.PageSize)
+            .Take(query.PageSize)
+            .Include(t => t.Outfit)
+            .Select(t => new TryOnHistoryDto(
+                t.Id,
+                t.OutfitID,
+                t.Outfit != null ? t.Outfit.OutfitName : "Unknown",
+                t.Outfit != null ? t.Outfit.MainImageURL : null,
+                t.ResultPhotoURL,
+                t.UploadedPhotoURL,
+                t.TryOnTimestamp
+            ))
+            .ToListAsync(ct);
+
+        return Result<GetParentTryOnHistoryResponse>.Success(
+            new GetParentTryOnHistoryResponse(items, total, query.Page, query.PageSize));
+    }
+}

--- a/VTOS.Domain/Entities/ChatMessage.cs
+++ b/VTOS.Domain/Entities/ChatMessage.cs
@@ -16,6 +16,18 @@ public class ChatMessage : BaseEntity
     public string Content { get; set; } = string.Empty;
     public DateTime SentAt { get; set; }
 
+    /// <summary>Type of message: Text, UniformProposal, or SystemNotification</summary>
+    public ChatMessageType MessageType { get; set; } = ChatMessageType.Text;
+
+    /// <summary>Image URL for uniform proposals and system confirmations</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Status of a uniform proposal: null, Pending, Accepted, Rejected</summary>
+    public string? ProposalStatus { get; set; }
+
+    /// <summary>Name of the proposed uniform (set by Provider)</summary>
+    public string? ProposalOutfitName { get; set; }
+
     // Navigation
     public User Sender { get; set; } = null!;
 }

--- a/VTOS.Domain/Enums/ChatMessageType.cs
+++ b/VTOS.Domain/Enums/ChatMessageType.cs
@@ -1,0 +1,8 @@
+namespace VTOS.Domain.Enums;
+
+public enum ChatMessageType
+{
+    Text = 1,
+    UniformProposal = 2,
+    SystemNotification = 3
+}

--- a/VTOS.Infrastructure/DependencyInjection.cs
+++ b/VTOS.Infrastructure/DependencyInjection.cs
@@ -177,6 +177,8 @@ public static class DependencyInjection
 
         // TryOn Module Handlers (UC-60)
         services.AddScoped<IGuestTryOnCommandHandler, GuestTryOnCommandHandler>();
+        services.AddScoped<VTOS.Application.Features.TryOn.Queries.IGetParentTryOnHistoryQueryHandler,
+            VTOS.Application.Features.TryOn.Queries.GetParentTryOnHistoryQueryHandler>();
 
         // Orders Module Handlers (Checkout, Cancel, Track Status, History)
         services.AddScoped<ICheckoutCommandHandler, CheckoutCommandHandler>();
@@ -409,6 +411,10 @@ public static class DependencyInjection
             VTOS.Application.Features.Chat.Queries.GetChatMessagesQueryHandler>();
         services.AddScoped<VTOS.Application.Features.Chat.Commands.ISendChatMessageCommandHandler,
             VTOS.Application.Features.Chat.Commands.SendChatMessageCommandHandler>();
+        services.AddScoped<VTOS.Application.Features.Chat.Commands.ISendUniformProposalCommandHandler,
+            VTOS.Application.Features.Chat.Commands.SendUniformProposalCommandHandler>();
+        services.AddScoped<VTOS.Application.Features.Chat.Commands.IAcceptUniformProposalCommandHandler,
+            VTOS.Application.Features.Chat.Commands.AcceptUniformProposalCommandHandler>();
         services.AddScoped<VTOS.Application.Abstractions.IChatBroadcaster,
             VTOS.Infrastructure.Hubs.SignalRChatBroadcaster>();
 
@@ -419,6 +425,8 @@ public static class DependencyInjection
             VTOS.Application.Features.Contracts.Commands.ApproveContractCommandHandler>();
         services.AddScoped<VTOS.Application.Features.Contracts.Commands.IRejectContractCommandHandler,
             VTOS.Application.Features.Contracts.Commands.RejectContractCommandHandler>();
+        services.AddScoped<VTOS.Application.Features.Contracts.Commands.ICancelContractCommandHandler,
+            VTOS.Application.Features.Contracts.Commands.CancelContractCommandHandler>();
         services.AddScoped<VTOS.Application.Features.Contracts.Queries.IGetContractsQueryHandler,
             VTOS.Application.Features.Contracts.Queries.GetContractsQueryHandler>();
         services.AddScoped<VTOS.Application.Features.Contracts.Queries.IGetContractDetailQueryHandler,

--- a/VTOS.Infrastructure/ExternalServices/ImageStorage/MinioImageService.cs
+++ b/VTOS.Infrastructure/ExternalServices/ImageStorage/MinioImageService.cs
@@ -14,7 +14,7 @@ public class MinioImageService : IImageUploadService
     private readonly IMinioClient _minioClient;
     private readonly MinioSettings _settings;
     private readonly ILogger<MinioImageService> _logger;
-    private bool _bucketEnsured = false;
+    private static bool _bucketEnsured = false;
 
     public MinioImageService(
         IOptions<MinioSettings> settings,
@@ -84,7 +84,8 @@ public class MinioImageService : IImageUploadService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error uploading image to MinIO: {FileName}", fileName);
+            _logger.LogError(ex, "Error uploading image to MinIO. FileName: {FileName}, Folder: {Folder}, Bucket: {Bucket}",
+                fileName, folder ?? "root", _settings.BucketName);
             throw new InvalidOperationException($"Image upload failed: {ex.Message}", ex);
         }
     }

--- a/VTOS.Infrastructure/Migrations/20260407181717_AddChatMessageProposalFields.Designer.cs
+++ b/VTOS.Infrastructure/Migrations/20260407181717_AddChatMessageProposalFields.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VTOS.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using VTOS.Infrastructure.Persistence;
 namespace VTOS.Infrastructure.Migrations
 {
     [DbContext(typeof(VTOSDbContext))]
-    partial class VTOSDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407181717_AddChatMessageProposalFields")]
+    partial class AddChatMessageProposalFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VTOS.Infrastructure/Migrations/20260407181717_AddChatMessageProposalFields.cs
+++ b/VTOS.Infrastructure/Migrations/20260407181717_AddChatMessageProposalFields.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VTOS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChatMessageProposalFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ImageUrl",
+                table: "ChatMessages",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MessageType",
+                table: "ChatMessages",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProposalOutfitName",
+                table: "ChatMessages",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProposalStatus",
+                table: "ChatMessages",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImageUrl",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "MessageType",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ProposalOutfitName",
+                table: "ChatMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ProposalStatus",
+                table: "ChatMessages");
+        }
+    }
+}

--- a/VTOS.Infrastructure/Persistence/Configurations/ChatMessageConfiguration.cs
+++ b/VTOS.Infrastructure/Persistence/Configurations/ChatMessageConfiguration.cs
@@ -33,6 +33,19 @@ public class ChatMessageConfiguration : IEntityTypeConfiguration<ChatMessage>
         builder.Property(m => m.SentAt)
             .IsRequired();
 
+        builder.Property(m => m.MessageType)
+            .IsRequired()
+            .HasDefaultValue(VTOS.Domain.Enums.ChatMessageType.Text);
+
+        builder.Property(m => m.ImageUrl)
+            .HasMaxLength(2000);
+
+        builder.Property(m => m.ProposalStatus)
+            .HasMaxLength(20);
+
+        builder.Property(m => m.ProposalOutfitName)
+            .HasMaxLength(200);
+
         // Index for fast lookups: all messages in a channel, ordered by time
         builder.HasIndex(m => new { m.ChannelType, m.ChannelId, m.SentAt });
 


### PR DESCRIPTION
- Rename /api/tryon/guest -> /api/tryon/request (unified endpoint)
- Add GET /api/tryon/history for Parent try-on history
- Add contract cancellation for Pending status (School)
- Add uniform proposal system in contract chat
- ChatMessage extended with MessageType, ImageUrl, ProposalStatus
- Fix MinIO _bucketEnsured made static
- Migration: AddChatMessageProposalFields