### PR TITLE
feat: add text overflow protection & outfit name limit (50 chars)

### DIFF
--- a/VTOS.Application/Features/AccountRequests/Commands/AccountRequestCommandHandlers.cs
+++ b/VTOS.Application/Features/AccountRequests/Commands/AccountRequestCommandHandlers.cs
@@ -64,12 +64,18 @@ public class SubmitAccountRequestCommandHandler : ISubmitAccountRequestCommandHa
         // Validate required fields
         if (string.IsNullOrWhiteSpace(req.OrganizationName))
             return Result<AccountRequestDetailDto>.Failure("Tên tổ chức không được để trống.", "VALIDATION");
+        if (req.OrganizationName.Length > 200)
+            return Result<AccountRequestDetailDto>.Failure("Tên tổ chức không được vượt quá 200 ký tự.", "ORG_NAME_TOO_LONG");
         if (string.IsNullOrWhiteSpace(req.ContactEmail))
             return Result<AccountRequestDetailDto>.Failure("Email không được để trống.", "VALIDATION");
         if (string.IsNullOrWhiteSpace(req.ContactPhone))
             return Result<AccountRequestDetailDto>.Failure("Số điện thoại không được để trống.", "VALIDATION");
         if (req.Type != 1 && req.Type != 2)
             return Result<AccountRequestDetailDto>.Failure("Loại tài khoản không hợp lệ.", "VALIDATION");
+        if (req.Description != null && req.Description.Length > 1000)
+            return Result<AccountRequestDetailDto>.Failure("Mô tả không được vượt quá 1000 ký tự.", "DESCRIPTION_TOO_LONG");
+        if (req.Address != null && req.Address.Length > 500)
+            return Result<AccountRequestDetailDto>.Failure("Địa chỉ không được vượt quá 500 ký tự.", "ADDRESS_TOO_LONG");
 
         // Check duplicate pending requests by email
         var existingRequest = await _context.AccountRequests
@@ -297,6 +303,8 @@ public class RejectAccountRequestCommandHandler : IRejectAccountRequestCommandHa
                 $"Yêu cầu đã được xử lý ({accountRequest.Status}).", "ALREADY_PROCESSED");
 
         accountRequest.Status = AccountRequestStatus.Rejected;
+        if (command.Reason != null && command.Reason.Length > 500)
+            return Result<AccountRequestDetailDto>.Failure("Lý do từ chối không được vượt quá 500 ký tự.", "REASON_TOO_LONG");
         accountRequest.RejectionReason = command.Reason;
         accountRequest.ProcessedByUserId = command.AdminUserId;
         accountRequest.ProcessedAt = DateTime.UtcNow;

--- a/VTOS.Application/Features/Chat/Commands/SendChatMessageCommand.cs
+++ b/VTOS.Application/Features/Chat/Commands/SendChatMessageCommand.cs
@@ -32,6 +32,9 @@ public class SendChatMessageCommandHandler : ISendChatMessageCommandHandler
         if (string.IsNullOrWhiteSpace(command.Content))
             return Result<SendChatMessageResponse>.Failure("Message content is required.", "CONTENT_REQUIRED");
 
+        if (command.Content.Length > 2000)
+            return Result<SendChatMessageResponse>.Failure("Message content cannot exceed 2000 characters.", "CONTENT_TOO_LONG");
+
         var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == command.UserId, ct);
         if (user == null)
             return Result<SendChatMessageResponse>.Failure("User not found.", "USER_NOT_FOUND");

--- a/VTOS.Application/Features/Chat/Commands/SendUniformProposalCommand.cs
+++ b/VTOS.Application/Features/Chat/Commands/SendUniformProposalCommand.cs
@@ -40,8 +40,14 @@ public class SendUniformProposalCommandHandler : ISendUniformProposalCommandHand
         if (string.IsNullOrWhiteSpace(command.ImageUrl))
             return Result<SendUniformProposalResponse>.Failure("Image URL is required for a uniform proposal.", "IMAGE_REQUIRED");
 
+        if (command.ImageUrl.Length > 500)
+            return Result<SendUniformProposalResponse>.Failure("Image URL cannot exceed 500 characters.", "IMAGE_URL_TOO_LONG");
+
         if (string.IsNullOrWhiteSpace(command.OutfitName))
             return Result<SendUniformProposalResponse>.Failure("Outfit name is required.", "NAME_REQUIRED");
+
+        if (command.OutfitName.Length > 100)
+            return Result<SendUniformProposalResponse>.Failure("Outfit name cannot exceed 100 characters.", "NAME_TOO_LONG");
 
         var user = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == command.UserId, ct);
         if (user == null)

--- a/VTOS.Application/Features/Contracts/Commands/ContractCommandHandlers.cs
+++ b/VTOS.Application/Features/Contracts/Commands/ContractCommandHandlers.cs
@@ -52,6 +52,11 @@ public class CreateContractCommandHandler : ICreateContractCommandHandler
         var schoolId = schoolMgr.SchoolID;
         var req = command.Request;
 
+        if (string.IsNullOrWhiteSpace(req.ContractName))
+            return Result<ContractDto>.Failure("Contract name is required.", "NAME_REQUIRED");
+        if (req.ContractName.Length > 200)
+            return Result<ContractDto>.Failure("Contract name cannot exceed 200 characters.", "NAME_TOO_LONG");
+
         // Validate provider exists
         var provider = await _context.Providers.FindAsync(new object[] { req.ProviderId }, ct);
         if (provider == null)
@@ -270,6 +275,11 @@ public class RejectContractCommandHandler : IRejectContractCommandHandler
             return Result<ContractDto>.Failure(
                 $"Contract is '{contract.Status}', only Pending contracts can be rejected.",
                 "INVALID_STATUS");
+
+        if (string.IsNullOrWhiteSpace(command.Reason))
+            return Result<ContractDto>.Failure("Rejection reason is required.", "REASON_REQUIRED");
+        if (command.Reason.Length > 500)
+            return Result<ContractDto>.Failure("Rejection reason cannot exceed 500 characters.", "REASON_TOO_LONG");
 
         contract.Status = "Rejected";
         contract.RejectedAt = DateTime.UtcNow;

--- a/VTOS.Application/Features/Feedbacks/Commands/SubmitFeedbackCommandHandler.cs
+++ b/VTOS.Application/Features/Feedbacks/Commands/SubmitFeedbackCommandHandler.cs
@@ -28,6 +28,14 @@ public class SubmitFeedbackCommandHandler : ISubmitFeedbackCommandHandler
                 "INVALID_RATING");
         }
 
+        // Validate comment length
+        if (command.Comment != null && command.Comment.Length > 500)
+        {
+            return Result<SubmitFeedbackResponse>.Failure(
+                "Comment cannot exceed 500 characters.",
+                "COMMENT_TOO_LONG");
+        }
+
         // Verify OrderItem exists and belongs to this user's order
         var orderItem = await _context.OrderItems
             .Include(oi => oi.Order)

--- a/VTOS.Application/Features/Schools/Commands/CreateOutfitCommandHandler.cs
+++ b/VTOS.Application/Features/Schools/Commands/CreateOutfitCommandHandler.cs
@@ -34,6 +34,16 @@ public class CreateOutfitCommandHandler : ICreateOutfitCommandHandler
         if (schoolMgr == null)
             return Result<OutfitDto>.Failure("School profile not set up yet. Please create your school profile first.", "SCHOOL_NOT_FOUND");
 
+        // Validate field lengths against DB constraints
+        if (string.IsNullOrWhiteSpace(command.OutfitName))
+            return Result<OutfitDto>.Failure("Outfit name is required.", "NAME_REQUIRED");
+        if (command.OutfitName.Length > 50)
+            return Result<OutfitDto>.Failure("Outfit name cannot exceed 50 characters.", "NAME_TOO_LONG");
+        if (command.Description != null && command.Description.Length > 500)
+            return Result<OutfitDto>.Failure("Description cannot exceed 500 characters.", "DESCRIPTION_TOO_LONG");
+        if (command.MainImageURL != null && command.MainImageURL.Length > 500)
+            return Result<OutfitDto>.Failure("Image URL cannot exceed 500 characters.", "IMAGE_URL_TOO_LONG");
+
         var outfit = new Outfit
         {
             Id = Guid.NewGuid(),

--- a/VTOS.Application/Features/Schools/Commands/UpdateOutfitCommandHandler.cs
+++ b/VTOS.Application/Features/Schools/Commands/UpdateOutfitCommandHandler.cs
@@ -43,6 +43,14 @@ public class UpdateOutfitCommandHandler : IUpdateOutfitCommandHandler
         if (outfit.SchoolID != schoolMgr.SchoolID)
             return Result<OutfitDto>.Failure("You do not have permission to update this outfit.", "OUTFIT_NOT_FOUND");
 
+        // Validate field lengths against DB constraints
+        if (command.OutfitName != null && command.OutfitName.Length > 50)
+            return Result<OutfitDto>.Failure("Outfit name cannot exceed 50 characters.", "NAME_TOO_LONG");
+        if (command.Description != null && command.Description.Length > 500)
+            return Result<OutfitDto>.Failure("Description cannot exceed 500 characters.", "DESCRIPTION_TOO_LONG");
+        if (command.MainImageURL != null && command.MainImageURL.Length > 500)
+            return Result<OutfitDto>.Failure("Image URL cannot exceed 500 characters.", "IMAGE_URL_TOO_LONG");
+
         // Partial update — only apply non-null fields
         if (command.OutfitName != null) outfit.OutfitName = command.OutfitName;
         if (command.Description != null) outfit.Description = command.Description;


### PR DESCRIPTION
- Backend: Add length validation in CreateOutfit/UpdateOutfit handlers
- Backend: Add validation guards in Chat, Contract, Feedback, AccountRequest handlers
- Outfit name limit: 255 -> 50 chars (FE + BE)
- Description limit: 500 chars with backend rejection