### PR TITLE
feat: public search API, real-time user status via SignalR, phone nor…

### DIFF
--- a/VTOS.API/Controllers/AdminController.cs
+++ b/VTOS.API/Controllers/AdminController.cs
@@ -171,7 +171,7 @@ public class AdminController : ControllerBase
 
         if (!success) return NotFound();
 
-        return Ok();
+        return NoContent();
     }
 
     // ✅ Suspend User
@@ -183,7 +183,7 @@ public class AdminController : ControllerBase
 
         if (!success) return NotFound();
 
-        return Ok();
+        return NoContent();
     }
 
     // ✅ Remove Feedback

--- a/VTOS.API/Controllers/PublicController.cs
+++ b/VTOS.API/Controllers/PublicController.cs
@@ -20,6 +20,7 @@ public class PublicController : ControllerBase
     private readonly GetSchoolDetailQueryHandler _getSchoolDetailHandler;
     private readonly GetUniformListQueryHandler _getUniformListHandler;
     private readonly GetPublicCampaignDetailQueryHandler _getPublicCampaignDetailHandler;
+    private readonly PublicSearchQueryHandler _publicSearchHandler;
 
     public PublicController(
         GetSchoolsQueryHandler getSchoolsHandler,
@@ -27,7 +28,8 @@ public class PublicController : ControllerBase
         GetOutfitDetailQueryHandler getOutfitDetailHandler,
         GetSchoolDetailQueryHandler getSchoolDetailHandler,
         GetUniformListQueryHandler getUniformListHandler,
-        GetPublicCampaignDetailQueryHandler getPublicCampaignDetailHandler)
+        GetPublicCampaignDetailQueryHandler getPublicCampaignDetailHandler,
+        PublicSearchQueryHandler publicSearchHandler)
     {
         _getSchoolsHandler = getSchoolsHandler;
         _getCategoriesHandler = getCategoriesHandler;
@@ -35,6 +37,7 @@ public class PublicController : ControllerBase
         _getSchoolDetailHandler = getSchoolDetailHandler;
         _getUniformListHandler = getUniformListHandler;
         _getPublicCampaignDetailHandler = getPublicCampaignDetailHandler;
+        _publicSearchHandler = publicSearchHandler;
     }
 
     /// <summary>
@@ -53,6 +56,27 @@ public class PublicController : ControllerBase
     {
         var query = new GetSchoolsQuery(search, page, pageSize);
         var result = await _getSchoolsHandler.HandleAsync(query, ct);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Unified search across schools and uniforms.
+    /// Returns schools and uniforms matching the query (case-insensitive contains).
+    /// Used by the navbar search bar.
+    /// </summary>
+    /// <param name="q">Search keyword</param>
+    /// <param name="page">Page number (default: 1)</param>
+    /// <param name="pageSize">Items per section (default: 10)</param>
+    [HttpGet("search")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Search(
+        [FromQuery] string? q,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        CancellationToken ct = default)
+    {
+        var query = new PublicSearchQuery(q, page, pageSize);
+        var result = await _publicSearchHandler.HandleAsync(query, ct);
         return Ok(result);
     }
 

--- a/VTOS.API/Controllers/SchoolsController.cs
+++ b/VTOS.API/Controllers/SchoolsController.cs
@@ -624,6 +624,21 @@ public class SchoolsController : ControllerBase
     }
 
     /// <summary>
+    /// Toggle uniform visibility (hide/show from public listing).
+    /// Use this when an outfit is in a Completed campaign and cannot be deleted.
+    /// </summary>
+    [HttpPatch("me/outfits/{id:guid}/availability")]
+    [ProducesResponseType(typeof(OutfitDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> SetOutfitAvailability(Guid id, [FromBody] SetOutfitAvailabilityRequest request, CancellationToken ct)
+    {
+        var userId = _currentUser.UserId;
+        var result = await _updateOutfitHandler.HandleAsync(
+            new UpdateOutfitCommand(userId, id, null, null, null, null, null, null, request.IsAvailable, null), ct);
+        if (!result.IsSuccess) return BadRequest(new { error = result.Error, code = result.ErrorCode });
+        return Ok(result.Value);
+    }
+
+    /// <summary>
     /// Upload an image for an outfit (returns the hosted URL).
     /// </summary>
     [HttpPost("me/outfits/upload-image")]
@@ -1498,4 +1513,7 @@ public record UpdateOutfitRequest(
     bool? IsAvailable = null,
     bool? IsCustomizable = null
 );
+
+/// <summary>Request body for toggling outfit visibility.</summary>
+public record SetOutfitAvailabilityRequest(bool IsAvailable);
 

--- a/VTOS.Application/Features/AccountRequests/Commands/AccountRequestCommandHandlers.cs
+++ b/VTOS.Application/Features/AccountRequests/Commands/AccountRequestCommandHandlers.cs
@@ -162,6 +162,16 @@ public class CreateAccountForRequestCommandHandler : ICreateAccountForRequestCom
             return Result<AccountRequestDetailDto>.Failure(
                 $"Email '{email}' đã tồn tại trong hệ thống.", "EMAIL_EXISTS");
 
+        // Check if phone is already used by another user (if provided)
+        if (!string.IsNullOrWhiteSpace(req.Phone))
+        {
+            var normalizedPhone = NormalizePhone(req.Phone);
+            var phoneExists = await _context.Users.AnyAsync(u => u.Phone == normalizedPhone, ct);
+            if (phoneExists)
+                return Result<AccountRequestDetailDto>.Failure(
+                    "Số điện thoại đã được sử dụng bởi tài khoản khác.", "PHONE_ALREADY_USED");
+        }
+
         // Determine role
         var roleName = accountRequest.Type == AccountRequestType.School ? "School" : "Provider";
         var role = await _context.Roles.FirstOrDefaultAsync(r => r.RoleName == roleName, ct);
@@ -188,7 +198,7 @@ public class CreateAccountForRequestCommandHandler : ICreateAccountForRequestCom
             Email = email,
             PasswordHash = _passwordHasher.HashPassword(tempPassword),
             FullName = req.FullName?.Trim() ?? accountRequest.ContactPersonName ?? "User",
-            Phone = req.Phone?.Trim(),
+            Phone = !string.IsNullOrWhiteSpace(req.Phone) ? NormalizePhone(req.Phone) : null,
             RoleID = role.Id,
             IsActive = true,  // Active immediately (no OTP needed — admin-created)
             IsDeleted = false,
@@ -279,6 +289,16 @@ public class CreateAccountForRequestCommandHandler : ICreateAccountForRequestCom
         const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$";
         var random = new Random();
         return new string(Enumerable.Repeat(chars, 12).Select(s => s[random.Next(s.Length)]).ToArray());
+    }
+
+    /// <summary>Normalizes a phone number to local "0xxxxxxxxx" format.</summary>
+    private static string NormalizePhone(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return "";
+        var digits = new string(phone.Where(char.IsDigit).ToArray());
+        if (digits.StartsWith("84")) digits = digits[2..];
+        if (digits.StartsWith("0")) digits = digits[1..];
+        return "0" + digits;
     }
 }
 

--- a/VTOS.Application/Features/Admin/Commands/ApproveUserCommandHandler.cs
+++ b/VTOS.Application/Features/Admin/Commands/ApproveUserCommandHandler.cs
@@ -6,10 +6,12 @@ namespace VTOS.Application.Features.Admin.Commands;
 public class ApproveUserCommandHandler : IApproveUserCommandHandler
 {
     private readonly IApplicationDbContext _context;
+    private readonly IUserStatusBroadcaster _broadcaster;
 
-    public ApproveUserCommandHandler(IApplicationDbContext context)
+    public ApproveUserCommandHandler(IApplicationDbContext context, IUserStatusBroadcaster broadcaster)
     {
         _context = context;
+        _broadcaster = broadcaster;
     }
 
     public async Task<bool> HandleAsync(
@@ -71,6 +73,9 @@ public class ApproveUserCommandHandler : IApproveUserCommandHandler
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        // Broadcast: all connected admin clients update their user status badge immediately
+        await _broadcaster.BroadcastUserStatusChangedAsync(user.Id, isActive: true, cancellationToken);
 
         return true;
     }

--- a/VTOS.Application/Features/Admin/Commands/IUserStatusBroadcaster.cs
+++ b/VTOS.Application/Features/Admin/Commands/IUserStatusBroadcaster.cs
@@ -1,0 +1,13 @@
+namespace VTOS.Application.Features.Admin.Commands;
+
+/// <summary>
+/// Abstraction for broadcasting user status change events to all connected admin clients.
+/// Implemented by SignalR in Infrastructure layer.
+/// </summary>
+public interface IUserStatusBroadcaster
+{
+    /// <summary>
+    /// Broadcasts a user status change (active/inactive) to all admin clients.
+    /// </summary>
+    Task BroadcastUserStatusChangedAsync(Guid userId, bool isActive, CancellationToken ct = default);
+}

--- a/VTOS.Application/Features/Admin/Commands/SuspendUserCommandHandler.cs
+++ b/VTOS.Application/Features/Admin/Commands/SuspendUserCommandHandler.cs
@@ -6,10 +6,12 @@ namespace VTOS.Application.Features.Admin.Commands;
 public class SuspendUserCommandHandler : ISuspendUserCommandHandler
 {
     private readonly IApplicationDbContext _context;
+    private readonly IUserStatusBroadcaster _broadcaster;
 
-    public SuspendUserCommandHandler(IApplicationDbContext context)
+    public SuspendUserCommandHandler(IApplicationDbContext context, IUserStatusBroadcaster broadcaster)
     {
         _context = context;
+        _broadcaster = broadcaster;
     }
 
     public async Task<bool> HandleAsync(
@@ -25,6 +27,9 @@ public class SuspendUserCommandHandler : ISuspendUserCommandHandler
         user.IsActive = false;
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        // Broadcast: all connected admin clients update their user status badge immediately
+        await _broadcaster.BroadcastUserStatusChangedAsync(user.Id, isActive: false, cancellationToken);
 
         return true;
     }

--- a/VTOS.Application/Features/Auth/Commands/VerifyPhoneCommand.cs
+++ b/VTOS.Application/Features/Auth/Commands/VerifyPhoneCommand.cs
@@ -43,9 +43,12 @@ public class VerifyPhoneCommandHandler
                 "USER_NOT_FOUND");
         }
 
-        // Check if phone is already used by another parent
+        // Normalize phone before checking and storing (handles +84, 84, 0 prefixes)
+        var normalizedPhone = NormalizePhone(command.Phone);
+
+        // Check if phone is already used by another user
         var existingUser = await _context.Users
-            .FirstOrDefaultAsync(u => u.Phone == command.Phone && u.Id != command.UserId, cancellationToken);
+            .FirstOrDefaultAsync(u => u.Phone == normalizedPhone && u.Id != command.UserId, cancellationToken);
 
         if (existingUser != null)
         {
@@ -54,13 +57,26 @@ public class VerifyPhoneCommandHandler
                 "PHONE_ALREADY_USED");
         }
 
-        // Save phone to user record
-        user.Phone = command.Phone;
+        // Save normalized phone to user record
+        user.Phone = normalizedPhone;
         await _context.SaveChangesAsync(cancellationToken);
 
         return Result<VerifyPhoneResponse>.Success(new VerifyPhoneResponse(
-            command.Phone,
+            normalizedPhone,
             "Số điện thoại đã được lưu thành công."
         ));
+    }
+
+    /// <summary>
+    /// Normalizes a phone number to local "0xxxxxxxxx" format.
+    /// Handles +84, 84, 0 prefixes — all stored as local format.
+    /// </summary>
+    private static string NormalizePhone(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return "";
+        var digits = new string(phone.Where(char.IsDigit).ToArray());
+        if (digits.StartsWith("84")) digits = digits[2..];
+        if (digits.StartsWith("0")) digits = digits[1..];
+        return "0" + digits;
     }
 }

--- a/VTOS.Application/Features/Public/DTOs/PublicSearchResponse.cs
+++ b/VTOS.Application/Features/Public/DTOs/PublicSearchResponse.cs
@@ -1,0 +1,32 @@
+namespace VTOS.Application.Features.Public.DTOs;
+
+/// <summary>
+/// Response DTO for the unified public search endpoint.
+/// Returns schools and uniforms matching the query.
+/// </summary>
+public class PublicSearchResponse
+{
+    public List<SchoolSearchResult> Schools { get; set; } = new();
+    public List<UniformSearchResult> Uniforms { get; set; } = new();
+    public int TotalSchools { get; set; }
+    public int TotalUniforms { get; set; }
+}
+
+public class SchoolSearchResult
+{
+    public Guid Id { get; set; }
+    public string SchoolName { get; set; } = string.Empty;
+    public string? LogoUrl { get; set; }
+    public string? Address { get; set; }
+    public int UniformCount { get; set; }
+}
+
+public class UniformSearchResult
+{
+    public Guid Id { get; set; }
+    public string OutfitName { get; set; } = string.Empty;
+    public string? MainImageUrl { get; set; }
+    public decimal Price { get; set; }
+    public string SchoolName { get; set; } = string.Empty;
+    public Guid SchoolId { get; set; }
+}

--- a/VTOS.Application/Features/Public/Queries/PublicSearchQuery.cs
+++ b/VTOS.Application/Features/Public/Queries/PublicSearchQuery.cs
@@ -1,0 +1,11 @@
+namespace VTOS.Application.Features.Public.Queries;
+
+/// <summary>
+/// Unified search query across schools and uniforms.
+/// No authentication required.
+/// </summary>
+public record PublicSearchQuery(
+    string? Q = null,
+    int Page = 1,
+    int PageSize = 10
+);

--- a/VTOS.Application/Features/Public/Queries/PublicSearchQueryHandler.cs
+++ b/VTOS.Application/Features/Public/Queries/PublicSearchQueryHandler.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VTOS.Application.Abstractions;
+using VTOS.Application.Features.Public.DTOs;
+using VTOS.Domain.Entities;
+
+namespace VTOS.Application.Features.Public.Queries;
+
+/// <summary>
+/// Unified search across schools and uniforms.
+/// Returns schools and uniforms matching the search query (case-insensitive contains).
+/// No authentication required.
+/// </summary>
+public class PublicSearchQueryHandler
+{
+    private readonly IApplicationDbContext _db;
+
+    public PublicSearchQueryHandler(IApplicationDbContext db) => _db = db;
+
+    public async Task<PublicSearchResponse> HandleAsync(PublicSearchQuery query, CancellationToken ct = default)
+    {
+        var searchTerm = query.Q?.Trim();
+        var isEmpty = string.IsNullOrWhiteSpace(searchTerm);
+
+        // ── Schools ──────────────────────────────────────────────────────────
+        IQueryable<School> schoolQuery = _db.Schools.AsNoTracking();
+
+        if (!isEmpty)
+        {
+            var term = searchTerm.ToLower();
+            schoolQuery = schoolQuery.Where(s =>
+                EF.Functions.Like(s.SchoolName.ToLower(), $"%{term}%")
+                || (s.ContactInfo != null && EF.Functions.Like(s.ContactInfo.ToLower(), $"%{term}%"))
+            );
+        }
+
+        var schools = await schoolQuery
+            .OrderBy(s => s.SchoolName)
+            .Take(query.PageSize)
+            .Select(s => new SchoolSearchResult
+            {
+                Id = s.Id,
+                SchoolName = s.SchoolName,
+                LogoUrl = s.LogoURL,
+                Address = s.ContactInfo,   // raw JSON — parsed below
+                UniformCount = s.Outfits.Count(o => !o.IsDeleted)
+            })
+            .ToListAsync(ct);
+
+        // ContactInfo is stored as JSON: {"email":"...","phone":"...","address":"...","foundedYear":...}
+        // Extract just the address string for display — avoid showing raw JSON in the UI
+        foreach (var school in schools)
+            school.Address = ExtractAddress(school.Address);
+
+        var totalSchools = await schoolQuery.CountAsync(ct);
+
+        // ── Uniforms ─────────────────────────────────────────────────────────
+        IQueryable<Outfit> outfitQuery = _db.Outfits
+            .AsNoTracking()
+            .Where(o => !o.IsDeleted && o.IsAvailable);
+
+        if (!isEmpty)
+        {
+            var term = searchTerm.ToLower();
+            outfitQuery = outfitQuery.Where(o =>
+                EF.Functions.Like(o.OutfitName.ToLower(), $"%{term}%")
+                || (o.Description != null && EF.Functions.Like(o.Description.ToLower(), $"%{term}%"))
+            );
+        }
+
+        var uniforms = await outfitQuery
+            .Include(o => o.School)
+            .OrderBy(o => o.OutfitName)
+            .Take(query.PageSize)
+            .Select(o => new UniformSearchResult
+            {
+                Id = o.Id,
+                OutfitName = o.OutfitName,
+                MainImageUrl = o.MainImageURL,
+                Price = o.Price,
+                SchoolName = o.School.SchoolName,
+                SchoolId = o.SchoolID
+            })
+            .ToListAsync(ct);
+
+        var totalUniforms = await outfitQuery.CountAsync(ct);
+
+        return new PublicSearchResponse
+        {
+            Schools = schools,
+            Uniforms = uniforms,
+            TotalSchools = totalSchools,
+            TotalUniforms = totalUniforms
+        };
+    }
+
+    /// <summary>
+    /// Extracts the "address" field from a ContactInfo JSON string.
+    /// Returns the raw value as-is if it's not JSON (plain text address).
+    /// Returns null if the input is null or the address field is missing.
+    /// </summary>
+    private static string? ExtractAddress(string? contactInfo)
+    {
+        if (string.IsNullOrWhiteSpace(contactInfo)) return null;
+        if (!contactInfo.TrimStart().StartsWith('{')) return contactInfo; // plain text, use as-is
+
+        try
+        {
+            using var doc = JsonDocument.Parse(contactInfo);
+            if (doc.RootElement.TryGetProperty("address", out var addressProp))
+                return addressProp.GetString();
+        }
+        catch (JsonException) { /* malformed JSON — fall through */ }
+
+        return null;
+    }
+}

--- a/VTOS.Application/Features/Schools/Commands/DeleteOutfitCommandHandler.cs
+++ b/VTOS.Application/Features/Schools/Commands/DeleteOutfitCommandHandler.cs
@@ -1,12 +1,15 @@
 using Microsoft.EntityFrameworkCore;
 using VTOS.Application.Abstractions;
 using VTOS.Application.Common;
+using VTOS.Domain.Enums;
 
 namespace VTOS.Application.Features.Schools.Commands;
 
 /// <summary>
 /// Soft-delete an outfit (sets IsDeleted = true).
 /// Validates that the outfit belongs to the current school.
+/// Blocked if the outfit is linked to an Active/Paused/Locked campaign
+/// (parents have placed orders — the outfit cannot be deleted).
 /// </summary>
 public class DeleteOutfitCommandHandler : IDeleteOutfitCommandHandler
 {
@@ -40,6 +43,20 @@ public class DeleteOutfitCommandHandler : IDeleteOutfitCommandHandler
         // Security: ensure the outfit belongs to this school
         if (outfit.SchoolID != schoolMgr.SchoolID)
             return Result<bool>.Failure("You do not have permission to delete this outfit.", "OUTFIT_NOT_FOUND");
+
+        // Block deletion if outfit is linked to an Active/Paused/Locked campaign
+        var hasActiveCampaign = await _db.CampaignOutfits
+            .AsNoTracking()
+            .AnyAsync(co =>
+                co.OutfitID == outfit.Id
+                && (co.Campaign.Status == CampaignStatus.Active
+                    || co.Campaign.Status == CampaignStatus.Paused
+                    || co.Campaign.Status == CampaignStatus.Locked), ct);
+
+        if (hasActiveCampaign)
+            return Result<bool>.Failure(
+                "Không thể xóa đồng phục đang thuộc chiến dịch đang hoạt động.",
+                "OUTFIT_IN_ACTIVE_CAMPAIGN");
 
         outfit.IsDeleted = true;
         outfit.UpdatedAt = DateTime.UtcNow;

--- a/VTOS.Application/Features/Schools/Commands/UpdateOutfitCommandHandler.cs
+++ b/VTOS.Application/Features/Schools/Commands/UpdateOutfitCommandHandler.cs
@@ -76,6 +76,7 @@ public class UpdateOutfitCommandHandler : IUpdateOutfitCommandHandler
             SizeChartID = outfit.SizeChartID,
             IsAvailable = outfit.IsAvailable,
             IsCustomizable = outfit.IsCustomizable,
+            CanDelete = true,
             CreatedAt = outfit.CreatedAt,
             UpdatedAt = outfit.UpdatedAt
         });

--- a/VTOS.Application/Features/Schools/DTOs/OutfitDto.cs
+++ b/VTOS.Application/Features/Schools/DTOs/OutfitDto.cs
@@ -16,6 +16,7 @@ public class OutfitDto
     public Guid? SizeChartID { get; set; }
     public bool IsAvailable { get; set; }
     public bool IsCustomizable { get; set; }
+    public bool CanDelete { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
 }

--- a/VTOS.Application/Features/Schools/Queries/GetSchoolOutfitsQueryHandler.cs
+++ b/VTOS.Application/Features/Schools/Queries/GetSchoolOutfitsQueryHandler.cs
@@ -2,12 +2,16 @@ using Microsoft.EntityFrameworkCore;
 using VTOS.Application.Abstractions;
 using VTOS.Application.Common;
 using VTOS.Application.Features.Schools.DTOs;
+using VTOS.Domain.Enums;
 
 namespace VTOS.Application.Features.Schools.Queries;
 
 /// <summary>
 /// Returns all non-deleted outfits belonging to the logged-in school.
 /// Optional filter: IsAvailable.
+/// Includes CanDelete flag: false if outfit is linked to ANY campaign (Active, Paused,
+/// Locked, Completed, or Cancelled) — parents may have ordered it. School uses "Ẩn"
+/// (set IsAvailable=false) instead of delete in that case.
 /// </summary>
 public class GetSchoolOutfitsQueryHandler : IGetSchoolOutfitsQueryHandler
 {
@@ -39,6 +43,18 @@ public class GetSchoolOutfitsQueryHandler : IGetSchoolOutfitsQueryHandler
         if (query.IsAvailable.HasValue)
             outfitsQuery = outfitsQuery.Where(o => o.IsAvailable == query.IsAvailable.Value);
 
+        // Outfits linked to ANY campaign (Active, Paused, Locked, Completed, Cancelled)
+        // cannot be deleted — parents may have placed orders in that campaign.
+        // School uses "Ẩn" (hide → set IsAvailable=false) instead of delete.
+        var nonDeletableIds = await _db.CampaignOutfits
+            .AsNoTracking()
+            .Where(co => _db.Outfits.AsNoTracking()
+                .Any(o => o.Id == co.OutfitID && o.SchoolID == schoolMgr.SchoolID && !o.IsDeleted))
+            .Select(co => co.OutfitID)
+            .ToListAsync(ct);
+
+        var nonDeletableSet = new HashSet<Guid>(nonDeletableIds);
+
         var outfits = await outfitsQuery
             .OrderByDescending(o => o.CreatedAt)
             .Select(o => new OutfitDto
@@ -56,6 +72,10 @@ public class GetSchoolOutfitsQueryHandler : IGetSchoolOutfitsQueryHandler
                 UpdatedAt = o.UpdatedAt
             })
             .ToListAsync(ct);
+
+        // Set CanDelete — false if outfit is in ANY campaign (should use "Ẩn" instead)
+        foreach (var outfit in outfits)
+            outfit.CanDelete = !nonDeletableSet.Contains(outfit.OutfitId);
 
         return Result<OutfitListResponse>.Success(new OutfitListResponse
         {

--- a/VTOS.Application/Features/Users/DTOs/GetProfileResponse.cs
+++ b/VTOS.Application/Features/Users/DTOs/GetProfileResponse.cs
@@ -11,5 +11,6 @@ public record GetProfileResponse(
     bool IsDeleted,
     DateTime CreatedAt,
     DateTime LastLogin,
-    string? Avatar
+    string? Avatar,
+    bool TwoFactorEnabled
 );

--- a/VTOS.Application/Features/Users/Queries/GetProfileQueryHandler.cs
+++ b/VTOS.Application/Features/Users/Queries/GetProfileQueryHandler.cs
@@ -55,7 +55,8 @@ public class GetProfileQueryHandler : IGetProfileQueryHandler
             user.IsDeleted,
             user.CreatedAt,
             user.LastLogin ?? DateTime.MinValue,
-            user.Avatar
+            user.Avatar,
+            user.IsTwoFactorEnabled
         ));
     }
 }

--- a/VTOS.Infrastructure/DependencyInjection.cs
+++ b/VTOS.Infrastructure/DependencyInjection.cs
@@ -174,6 +174,7 @@ public static class DependencyInjection
         services.AddScoped<GetSchoolDetailQueryHandler>();
         services.AddScoped<GetUniformListQueryHandler>();
         services.AddScoped<GetPublicCampaignDetailQueryHandler>();
+        services.AddScoped<PublicSearchQueryHandler>();
 
         // TryOn Module Handlers (UC-60)
         services.AddScoped<IGuestTryOnCommandHandler, GuestTryOnCommandHandler>();
@@ -194,6 +195,7 @@ public static class DependencyInjection
         services.AddHostedService<BackgroundJobs.CampaignDeadlineReminderJob>();
         services.AddHostedService<BackgroundJobs.AdminNotificationDigestJob>();
         services.AddScoped<Application.Features.Notifications.INotificationBroadcaster, Hubs.SignalRNotificationBroadcaster>();
+        services.AddScoped<Application.Features.Admin.Commands.IUserStatusBroadcaster, Hubs.SignalRUserStatusBroadcaster>();
 
         // Phase 04: Admin UI Revamp
         services.AddScoped<VTOS.Application.Features.Admin.Queries.IGetAdminCashFlowQueryHandler,

--- a/VTOS.Infrastructure/Hubs/SignalRUserStatusBroadcaster.cs
+++ b/VTOS.Infrastructure/Hubs/SignalRUserStatusBroadcaster.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.SignalR;
+using VTOS.Application.Features.Admin.Commands;
+using VTOS.Infrastructure.Hubs;
+
+namespace VTOS.Infrastructure.Hubs;
+
+/// <summary>
+/// SignalR implementation of IUserStatusBroadcaster.
+/// Broadcasts "UserStatusChanged" to ALL connected admin clients via Clients.All.
+/// This enables the admin users table to update in real-time across all open admin tabs.
+/// </summary>
+public class SignalRUserStatusBroadcaster : IUserStatusBroadcaster
+{
+    private readonly IHubContext<NotificationHub> _hubContext;
+
+    public SignalRUserStatusBroadcaster(IHubContext<NotificationHub> hubContext) => _hubContext = hubContext;
+
+    public async Task BroadcastUserStatusChangedAsync(Guid userId, bool isActive, CancellationToken ct = default)
+    {
+        // Broadcast to ALL connected clients (not a specific user group)
+        // Admin pages listen on this event to update user status badges instantly
+        await _hubContext.Clients.All.SendAsync("UserStatusChanged", userId.ToString(), isActive, ct);
+    }
+}

--- a/VTOS.Infrastructure/Persistence/VTOSDbContextFactory.cs
+++ b/VTOS.Infrastructure/Persistence/VTOSDbContextFactory.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace VTOS.Infrastructure.Persistence;
+
+/// <summary>
+/// Design-time factory used by EF Core CLI (add-migration, update-database).
+/// Bypasses the full app host to avoid ASPNETCORE_ENVIRONMENT / system env var
+/// pollution that caused Npgsql to be selected even on a local MSSQL machine.
+///
+/// Provider resolution order (first match wins):
+///   1. EF_MIGRATION_PROVIDER env var  (explicit override — set in PMC before add-migration)
+///   2. "DatabaseProvider" key in appsettings.Development.json
+///   3. "DatabaseProvider" key in appsettings.json
+///   4. Default → "SqlServer"
+///
+/// Intentionally does NOT call AddEnvironmentVariables() to prevent system-level
+/// DatabaseProvider=PostgreSQL from leaking in during local MSSQL development.
+/// </summary>
+public class VTOSDbContextFactory : IDesignTimeDbContextFactory<VTOSDbContext>
+{
+    public VTOSDbContext CreateDbContext(string[] args)
+    {
+        var apiProjectPath = ResolveApiProjectPath();
+
+        // Load config from appsettings files ONLY — no system env var pollution
+        var config = new ConfigurationBuilder()
+            .SetBasePath(apiProjectPath)
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .Build();
+
+        // Allow explicit override via EF_MIGRATION_PROVIDER env var
+        // e.g. set EF_MIGRATION_PROVIDER=PostgreSQL in PMC before add-migration
+        var provider = Environment.GetEnvironmentVariable("EF_MIGRATION_PROVIDER")
+            ?? config.GetValue<string>("DatabaseProvider")
+            ?? "SqlServer";
+
+        var connStr = config.GetConnectionString("DefaultConnection");
+
+        // Fallback: hardcoded local MSSQL if appsettings not found
+        if (string.IsNullOrWhiteSpace(connStr))
+        {
+            connStr = "Server=DESKTOP-P5MIN4R\\SQLEXPRESS;Database=VTOSDb;" +
+                      "User Id=sa;Password=123;TrustServerCertificate=True;" +
+                      "MultipleActiveResultSets=true";
+            Console.WriteLine("[VTOSDbContextFactory] WARNING: appsettings not found — " +
+                              "using hardcoded fallback MSSQL connection string.");
+        }
+
+        var optionsBuilder = new DbContextOptionsBuilder<VTOSDbContext>();
+
+        if (provider.Equals("PostgreSQL", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("[VTOSDbContextFactory] Using PostgreSQL provider.");
+            optionsBuilder.UseNpgsql(
+                connStr,
+                b => b.MigrationsAssembly(typeof(VTOSDbContext).Assembly.FullName));
+        }
+        else
+        {
+            Console.WriteLine("[VTOSDbContextFactory] Using SqlServer provider.");
+            optionsBuilder.UseSqlServer(
+                connStr,
+                b => b.MigrationsAssembly(typeof(VTOSDbContext).Assembly.FullName));
+        }
+
+        return new VTOSDbContext(optionsBuilder.Options);
+    }
+
+    /// <summary>
+    /// Resolves the VTOS.API project directory reliably across different
+    /// PMC working-directory conventions (project dir, solution root, bin/debug).
+    /// </summary>
+    private static string ResolveApiProjectPath()
+    {
+        // Strategy 1: relative to assembly location (bin/Debug/net8.0 → ../../../ → project root)
+        var assemblyDir = Path.GetDirectoryName(typeof(VTOSDbContextFactory).Assembly.Location) ?? "";
+        // bin/Debug/net8.0 → go up 3 levels → VTOS.Infrastructure root → ../VTOS.API
+        var fromAssembly = Path.GetFullPath(Path.Combine(assemblyDir, "../../../", "../VTOS.API"));
+        if (Directory.Exists(fromAssembly) && File.Exists(Path.Combine(fromAssembly, "appsettings.json")))
+            return fromAssembly;
+
+        // Strategy 2: relative to current working directory
+        var candidates = new[]
+        {
+            Path.Combine(Directory.GetCurrentDirectory(), "../VTOS.API"),
+            Path.Combine(Directory.GetCurrentDirectory(), "VTOS.API"),
+            Path.Combine(Directory.GetCurrentDirectory(), "../../VTOS.API"),
+        };
+
+        foreach (var candidate in candidates)
+        {
+            var full = Path.GetFullPath(candidate);
+            if (Directory.Exists(full) && File.Exists(Path.Combine(full, "appsettings.json")))
+                return full;
+        }
+
+        // Strategy 3: last resort — return current directory and let it fail gracefully
+        Console.WriteLine("[VTOSDbContextFactory] WARNING: Could not locate VTOS.API directory. " +
+                          "Using current directory as fallback.");
+        return Directory.GetCurrentDirectory();
+    }
+}


### PR DESCRIPTION
…malization, outfit hide/soft-delete, 2FA profile flag, design-time DB factory

- Add PublicSearchQuery + Handler: unified search for schools & uniforms (GET /api/public/search)
- Add IUserStatusBroadcaster + SignalR impl: broadcast user active/inactive to admin clients in real-time
- Add phone normalization (+84/84/0 → 0xxxxxxxxx) in VerifyPhone and AccountRequest handlers
- Add outfit soft-delete: DeleteOutfit checks campaign usage, returns canDelete flag in OutfitDto
- Add SetOutfitAvailability endpoint on SchoolsController (hide outfit from public)
- Add IsTwoFactorEnabled to GetProfileResponse
- Add VTOSDbContextFactory: design-time factory with provider auto-detection (EF_MIGRATION_PROVIDER env var override)
- Register PublicSearchQueryHandler and SignalRUserStatusBroadcaster in DI